### PR TITLE
Support clean HTTPS URLs in BraftonCurlPageURL.

### DIFF
--- a/BraftonwordpressPlugin.php
+++ b/BraftonwordpressPlugin.php
@@ -330,7 +330,7 @@ EOC;
 
         $pageURL .= "://";
 
-        if ($_SERVER["SERVER_PORT"] != "80")
+        if ($_SERVER["SERVER_PORT"] != "80" && $_SERVER["SERVER_PORT"] != "443")
             $pageURL .= $_SERVER["SERVER_NAME"] . ":" . $_SERVER["SERVER_PORT"] . $_SERVER["REQUEST_URI"];
         else
             $pageURL .= $_SERVER["SERVER_NAME"] . $_SERVER["REQUEST_URI"];


### PR DESCRIPTION
This keeps the OG metadata cleaner and is consistent with the existing
behaviour for HTTP with port 80.